### PR TITLE
Winsfix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Encoding: UTF-8
 Package: EaCoN
 Type: Package
 Title: EaCoN : Easy Copy Number !
-Version: 0.3.4-1
-Date: 2018-12-10
+Version: 0.3.5
+Date: 2020-08-17
 Author: Bastien Job
 Authors@R: person("Bastien", "Job", email = "bastien.job@inserm.fr", role = c("aut", "cre"))
 Depends: R(>= 3.1.0)

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,12 @@
 EaCoN
 -----
 
+v0.3.5 (20200817)*CloudyMonday*
+-----------------
+* CORR : Segment.*() : Added a patch to handle the NA behavior in copynumber::winsorize (error raised by new handling of NA values in runmed). The patch consists on applying winsorization on non-NA values only (whereas all values were transmitted in earlier versions).
+* CORR : WES.Bin() : Better handling of a possible desynch in chr names (when a canonical chr had no remaining values, its level was kept. This raised a rare error).
+* MOD : Many funcs : Fixed calls to the "%do%" and "%dopar" operators without loading it.
+
 v0.3.4-1 (20181210) *PostRoscovite*
 -----------------
 * CORR : SNP6.Process(), CSHD.Process() : Edited code to handle changes in the rcnorm package, to discard the "chromosomes" package dependency.
@@ -83,7 +89,7 @@ v0.3.0 (20180724) *PapoQueen*
 * All : Removed "EaCoN." prefix from most functions (less self-centric...)
 * All : Took care of vectors and columns that could be converted to factor or integer (to free some RAM up).
 * All : Added missing support for manual PELT penalty (only asymptotic mode was considered when SER.value was numeric).
-* SNP6 : Revamped BAF homozygous calling and rescaling. 
+* SNP6 : Revamped BAF homozygous calling and rescaling.
 * Defined the novel sets of default parameters for all supported technologies.
 * Redacted the README.md
 

--- a/R/EaCoN_functions.R
+++ b/R/EaCoN_functions.R
@@ -207,6 +207,16 @@ Segment.ASCAT <- function(data = NULL, mingap = 5E+06, smooth.k = NULL, BAF.filt
   #colnames(data$data$Tumor_LogR_wins) <- samplename
   #rm(list = c("cndf", "cndf.wins"))
   
+  ## Winsorization (for aesthetics) *FIXATTEMPT*
+  tmsg("Smoothing L2R (for plots)...")
+  cndf <- data.frame(Chr = rep(unlist(cs$chrom2chr[data$data$chrs]), vapply(data$data$ch, length, 1L)), Position = unlist(data$data$ch), MySample = data$data$Tumor_LogR[[1]], stringsAsFactors = FALSE)
+  l2r.nona <- !is.na(data$data$Tumor_LogR[[1]])
+  cndf <- cndf[l2r.nona,]
+  cndf.wins <- copynumber::winsorize(data = cndf, pos.unit = "bp", method = "mad", k = 5, tau = 1, verbose = FALSE)
+  data$data$Tumor_LogR_wins <- data$data$Tumor_LogR
+  data$data$Tumor_LogR_wins[l2r.nona,] <- cndf.wins[, 3, drop = FALSE]
+  colnames(data$data$Tumor_LogR_wins) <- samplename
+  rm(list = c("cndf", "cndf.wins", "l2r.nona"))
   
   ## PELT rescue
   if (!is.null(SER.pen)) {

--- a/R/EaCoN_functions.R
+++ b/R/EaCoN_functions.R
@@ -92,13 +92,13 @@ Segment.ASCAT <- function(data = NULL, mingap = 5E+06, smooth.k = NULL, BAF.filt
   
   
   ## Winsorization
-  if(!is.null(smooth.k)) {
-    tmsg("Smoothing L2R outliers ...")
-    cndf <- data.frame(Chr = rep(unlist(cs$chrom2chr[data$data$chrs]), vapply(data$data$ch, length, 1L)), Position = unlist(data$data$ch), MySample = data$data$Tumor_LogR[[1]], stringsAsFactors = FALSE)
-    cndf.wins <- copynumber::winsorize(data = cndf, pos.unit = "bp", method = "mad", k = smooth.k, tau = 1, verbose = FALSE)
-    data$data$Tumor_LogR[,1] <- cndf.wins[, 3, drop = FALSE]
-    rm(list = c("cndf", "cndf.wins"))
-  }
+  #if(!is.null(smooth.k)) {
+  #  tmsg("Smoothing L2R outliers ...")
+  #  cndf <- data.frame(Chr = rep(unlist(cs$chrom2chr[data$data$chrs]), vapply(data$data$ch, length, 1L)), Position = unlist(data$data$ch), MySample = data$data$Tumor_LogR[[1]], stringsAsFactors = FALSE)
+  #  cndf.wins <- copynumber::winsorize(data = cndf, pos.unit = "bp", method = "mad", k = smooth.k, tau = 1, verbose = FALSE)
+  #  data$data$Tumor_LogR[,1] <- cndf.wins[, 3, drop = FALSE]
+  #  rm(list = c("cndf", "cndf.wins"))
+  #}
   
   ## BAF filtering
   tmsg("Filtering BAF...")
@@ -200,12 +200,12 @@ Segment.ASCAT <- function(data = NULL, mingap = 5E+06, smooth.k = NULL, BAF.filt
   } else stop(tmsg("Invalid recentering method called !"), call. = FALSE)
   
   ## Winsorization (for aesthetics)
-  tmsg("Smoothing L2R (for plots)...")
-  cndf <- data.frame(Chr = rep(unlist(cs$chrom2chr[data$data$chrs]), vapply(data$data$ch, length, 1L)), Position = unlist(data$data$ch), MySample = data$data$Tumor_LogR[[1]], stringsAsFactors = FALSE)
-  cndf.wins <- copynumber::winsorize(data = cndf, pos.unit = "bp", method = "mad", k = 5, tau = 1, verbose = FALSE)
-  data$data$Tumor_LogR_wins <- cndf.wins[, 3, drop = FALSE]
-  colnames(data$data$Tumor_LogR_wins) <- samplename
-  rm(list = c("cndf", "cndf.wins"))
+  #tmsg("Smoothing L2R (for plots)...")
+  #cndf <- data.frame(Chr = rep(unlist(cs$chrom2chr[data$data$chrs]), vapply(data$data$ch, length, 1L)), Position = unlist(data$data$ch), MySample = data$data$Tumor_LogR[[1]], stringsAsFactors = FALSE)
+  #cndf.wins <- copynumber::winsorize(data = cndf, pos.unit = "bp", method = "mad", k = 5, tau = 1, verbose = FALSE)
+  #data$data$Tumor_LogR_wins <- cndf.wins[, 3, drop = FALSE]
+  #colnames(data$data$Tumor_LogR_wins) <- samplename
+  #rm(list = c("cndf", "cndf.wins"))
   
   
   ## PELT rescue
@@ -353,7 +353,8 @@ Segment.ASCAT <- function(data = NULL, mingap = 5E+06, smooth.k = NULL, BAF.filt
     l2r.value <- data.frame(Chr = l2r.chr,
                             Start = as.integer(data$data$SNPpos$pos),
                             End = as.integer(data$data$SNPpos$pos),
-                            Value = data$data$Tumor_LogR_wins[,1],
+                            #Value = data$data$Tumor_LogR_wins[,1],
+                            Value = data$data$Tumor_LogR[,1],
                             stringsAsFactors = FALSE)
     baf.value <- data.frame(Chr = l2r.chr,
                             Start = as.integer(data$data$SNPpos$pos),
@@ -475,13 +476,13 @@ Segment.FACETS <- function(data = NULL, smooth.k = NULL, BAF.filter = .75, homoC
   ))
   
   ## Winsorization
-  if(!is.null(smooth.k)) {
-    tmsg("Smoothing L2R outliers ...")
-    cndf <- data.frame(Chr = rep(unlist(cs$chrom2chr[data$data$chrs]), vapply(data$data$ch, length, 1L)), Position = unlist(data$data$ch), MySample = data$data$Tumor_LogR[[1]], stringsAsFactors = FALSE)
-    cndf.wins <- copynumber::winsorize(data = cndf, pos.unit = "bp", method = "mad", k = smooth.k, tau = 1, verbose = FALSE)
-    data$data$Tumor_LogR[,1] <- cndf.wins[, 3, drop = FALSE]
-    rm(list = c("cndf", "cndf.wins"))
-  }
+  #if(!is.null(smooth.k)) {
+  #  tmsg("Smoothing L2R outliers ...")
+  #  cndf <- data.frame(Chr = rep(unlist(cs$chrom2chr[data$data$chrs]), vapply(data$data$ch, length, 1L)), Position = unlist(data$data$ch), MySample = data$data$Tumor_LogR[[1]], stringsAsFactors = FALSE)
+  #  cndf.wins <- copynumber::winsorize(data = cndf, pos.unit = "bp", method = "mad", k = smooth.k, tau = 1, verbose = FALSE)
+  #  data$data$Tumor_LogR[,1] <- cndf.wins[, 3, drop = FALSE]
+  #  rm(list = c("cndf", "cndf.wins"))
+  #}
   
   ## BAF filtering
   tmsg("Filtering BAF...")
@@ -625,12 +626,12 @@ Segment.FACETS <- function(data = NULL, smooth.k = NULL, BAF.filter = .75, homoC
   } else stop(tmsg("Invalid recentering method called !"), call. = FALSE)
   
   ## Winsorization
-  tmsg("Smoothing L2R (for plots)...")
-  cndf <- data.frame(Chr = rep(unlist(cs$chrom2chr[data$data$chrs]), vapply(data$data$ch, length, 1L)), Position = unlist(data$data$ch), MySample = data$data$Tumor_LogR[[1]], stringsAsFactors = FALSE)
-  cndf.wins <- copynumber::winsorize(data = cndf, pos.unit = "bp", method = "mad", k = 5, tau = 1, verbose = FALSE)
-  data$data$Tumor_LogR_wins <- cndf.wins[, 3, drop = FALSE]
-  colnames(data$data$Tumor_LogR_wins) <- samplename
-  rm(list = c("cndf", "cndf.wins"))
+  #tmsg("Smoothing L2R (for plots)...")
+  #cndf <- data.frame(Chr = rep(unlist(cs$chrom2chr[data$data$chrs]), vapply(data$data$ch, length, 1L)), Position = unlist(data$data$ch), MySample = data$data$Tumor_LogR[[1]], stringsAsFactors = FALSE)
+  #cndf.wins <- copynumber::winsorize(data = cndf, pos.unit = "bp", method = "mad", k = 5, tau = 1, verbose = FALSE)
+  #data$data$Tumor_LogR_wins <- cndf.wins[, 3, drop = FALSE]
+  #colnames(data$data$Tumor_LogR_wins) <- samplename
+  #rm(list = c("cndf", "cndf.wins"))
   
   
   ## PELT rescue
@@ -781,7 +782,8 @@ Segment.FACETS <- function(data = NULL, smooth.k = NULL, BAF.filter = .75, homoC
     l2r.value <- data.frame(Chr = l2r.chr,
                             Start = data$data$SNPpos$pos,
                             End = data$data$SNPpos$pos,
-                            Value = data$data$Tumor_LogR_wins[,1],
+                            #Value = data$data$Tumor_LogR_wins[,1],
+                            Value = data$data$Tumor_LogR[,1],
                             stringsAsFactors = FALSE)
     # baf.chr <- if(length(grep(pattern = "chr", x = names(cs$chrom2chr), ignore.case = TRUE)) > 0) unlist(cs$chrom2chr[paste0("chr", as.character(data$data$SNPpos$chrs))]) else unlist(cs$chrom2chr[as.character(data$data$SNPpos$chrs)])
     baf.value <- data.frame(Chr = l2r.chr,
@@ -897,13 +899,13 @@ Segment.SEQUENZA <- function(data = NULL, smooth.k = NULL, BAF.filter = .75, hom
   ))
   
   ## Winsorization
-  if(!is.null(smooth.k)) {
-    tmsg("Smoothing L2R outliers ...")
-    cndf <- data.frame(Chr = rep(unlist(cs$chrom2chr[data$data$chrs]), vapply(data$data$ch, length, 1L)), Position = unlist(data$data$ch), MySample = data$data$Tumor_LogR[[1]], stringsAsFactors = FALSE)
-    cndf.wins <- copynumber::winsorize(data = cndf, pos.unit = "bp", method = "mad", k = smooth.k, tau = 1, verbose = FALSE)
-    data$data$Tumor_LogR[,1] <- cndf.wins[, 3, drop = FALSE]
-    rm(list = c("cndf", "cndf.wins"))
-  }
+  #if(!is.null(smooth.k)) {
+  #  tmsg("Smoothing L2R outliers ...")
+  #  cndf <- data.frame(Chr = rep(unlist(cs$chrom2chr[data$data$chrs]), vapply(data$data$ch, length, 1L)), Position = unlist(data$data$ch), MySample = data$data$Tumor_LogR[[1]], stringsAsFactors = FALSE)
+  #  cndf.wins <- copynumber::winsorize(data = cndf, pos.unit = "bp", method = "mad", k = smooth.k, tau = 1, verbose = FALSE)
+  #  data$data$Tumor_LogR[,1] <- cndf.wins[, 3, drop = FALSE]
+  #  rm(list = c("cndf", "cndf.wins"))
+  #}
   
   ## BAF filtering
   tmsg("Filtering BAF...")
@@ -1060,11 +1062,11 @@ Segment.SEQUENZA <- function(data = NULL, smooth.k = NULL, BAF.filter = .75, hom
   } else stop(tmsg("Invalid recentering method called !"), call. = FALSE)
   
   ## Winsorization
-  tmsg("Smoothing L2R (for plots)...")
-  cndf <- data.frame(Chr = rep(unlist(cs$chrom2chr[data$data$chrs]), vapply(data$data$ch, length, 1L)), Position = unlist(data$data$ch), MySample = data$data$Tumor_LogR[[1]], stringsAsFactors = FALSE)
-  cndf.wins <- copynumber::winsorize(data = cndf, pos.unit = "bp", method = "mad", k = 5, tau = 1, verbose = FALSE)
-  data$data$Tumor_LogR_wins <- cndf.wins[, 3, drop = FALSE]
-  colnames(data$data$Tumor_LogR_wins) <- samplename
+  #tmsg("Smoothing L2R (for plots)...")
+  #cndf <- data.frame(Chr = rep(unlist(cs$chrom2chr[data$data$chrs]), vapply(data$data$ch, length, 1L)), Position = unlist(data$data$ch), MySample = data$data$Tumor_LogR[[1]], stringsAsFactors = FALSE)
+  #cndf.wins <- copynumber::winsorize(data = cndf, pos.unit = "bp", method = "mad", k = 5, tau = 1, verbose = FALSE)
+  #data$data$Tumor_LogR_wins <- cndf.wins[, 3, drop = FALSE]
+  #colnames(data$data$Tumor_LogR_wins) <- samplename
   rm(list = c("cndf", "cndf.wins"))
   
   
@@ -1216,7 +1218,8 @@ Segment.SEQUENZA <- function(data = NULL, smooth.k = NULL, BAF.filter = .75, hom
     l2r.value <- data.frame(Chr = l2r.chr,
                             Start = data$data$SNPpos$pos,
                             End = data$data$SNPpos$pos,
-                            Value = data$data$Tumor_LogR_wins[,1],
+                            #Value = data$data$Tumor_LogR_wins[,1],
+                            Value = data$data$Tumor_LogR[,1],
                             stringsAsFactors = FALSE)
     # baf.chr <- if(length(grep(pattern = "chr", x = names(cs$chrom2chr), ignore.case = TRUE)) > 0) unlist(cs$chrom2chr[paste0("chr", as.character(data$data$SNPpos$chrs))]) else unlist(cs$chrom2chr[as.character(data$data$SNPpos$chrs)])
     baf.value <- data.frame(Chr = l2r.chr,

--- a/R/wes_process.R
+++ b/R/wes_process.R
@@ -338,6 +338,10 @@ WES.Bin <- function(testBAM = NULL, refBAM = NULL, BINpack = NULL, samplename = 
   meta.w$SNP.tot.count.ref.summary <- my.summary(SNP.all$tot_count.ref[!is.na(SNP.all$tot_count.ref)])
   gc()
   
+  ## Cleaning uncovered chr levels
+  CN.all$chr <- droplevels(CN.all$chr)
+  SNP.all$chr <- droplevels(SNP.all$chr)
+  
   WESobj <- list(RD = CN.all, SNP = SNP.all, meta = list(basic = meta.b, WES = meta.w))
   rm(CN.all, SNP.all)
   gc()


### PR DESCRIPTION
Merging the winsfix branch to master (patch tested)
. As of R3.2, the _runmed()_ function now has new options to handle NA values. Unfortunately, the _copynumber::winsorize()_ dependence EaCoN uses relies upon the runmed() function, but wasn't updated to comply to this new parameter. So I built a quick fix by forcing winsorize() to compute on the non-NA part of L2R values.